### PR TITLE
Update link to writeup

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,4 @@ https://github.com/JOSHUAJEBARAJ/GCP-GOAT
 [Sarthak Bokade](https://www.linkedin.com/in/sarthak-bokade-1a0321224/) has written a wonderful writeup about this CTF! It contains a step-by-step guide, in case you get stuck. 
 Ultimate kudos to him!!
 
-https://cloudsecurity.club/blog/solving-gcp-pentest-lab-ctf/
+https://cloudsecurity.club/p/solving-gcp-pentest-lab-ctf/


### PR DESCRIPTION
There was recent change in the website hosting. The old URL doesn't work.